### PR TITLE
Remove Bastion and RealisticBiome from private config

### DIFF
--- a/templates/stacks/minecraft.yml.j2
+++ b/templates/stacks/minecraft.yml.j2
@@ -68,12 +68,10 @@ services:
     volumes:
       - /opt/stacks/minecraft/paper-data:/data
       # Private Config & Plugins
-      - /opt/PrivateConfig/paper/config/RealisticBiomes/config.yml:/config/plugins/RealisticBiomes/config.yml
       - /opt/PrivateConfig/paper/plugins/Vulcan-2.8.5.jar:/config/plugins/Vulcan-2.8.5.jar
       - /opt/PrivateConfig/paper/config/Vulcan/config.yml:/config/plugins/Vulcan/config.yml
       - /opt/PrivateConfig/paper/config/HiddenOre/config.yml:/config/plugins/HiddenOre/config.yml
       - /opt/PrivateConfig/paper/config/KiraBukkitGateway/config.yml:/config/plugins/KirraBukkitGateway/cnfig.yml
-      - /opt/PrivateConfig/paper/config/Bastion/config.yml:/config/plugins/Bastion/config.yml
       - /opt/PrivateConfig/paper/config/Brewery/config.yml:/config/plugins/Brewery/config.yml
       - /opt/PrivateConfig/paper/config/Terra/packs/CivMC:/config/plugins/Terra/packs/CivMC
       - /opt/PrivateConfig/paper/config/Votifier/config.yml:/config/plugins/Votifier/config.yml


### PR DESCRIPTION
We'll be using the docker one, now they're public